### PR TITLE
Allow to use more than 1 pair of inbound and outbound signatures

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,7 +30,7 @@ As Ogone works with in and out signatures, you will have to set these as constan
     c.inbound_signature  = '094598439859385938958398494' # You can find this under "Data and origin verification" tab
   end
 
-Make sure that Ogone is set to "Each parameter followed by the pass phrase." as hashed value (under "Global security parameters"). 
+Make sure that Ogone is set to "Each parameter followed by the pass phrase." as hashed value (under "Global security parameters").
 If you don't see this setting, then you're probably already in that mode.
 
 == Example Usage
@@ -41,12 +41,12 @@ Once you've configured the Ogone settings you need to set up a leaving page with
       :amount   => @order.price * 100 # needs to be in cents
       :currency   => 'EUR',
       :service  => :ogone do |service| %>
-    
+
     <%  service.redirect :accepturl => checkout_url(@order),
                :cancelurl => checkout_url(@order),
                :declineurl => checkout_url(@order),
                :exceptionurl => checkout_url(@order) %>
-    
+
     <%= submit_tag "Pay with Ogone!" %>
   <% end %>
 
@@ -54,10 +54,50 @@ And in your controller you should have an enter path:
 
   class CheckoutsController < ApplicationController
     include ActiveMerchant::Billing::Integrations
-    
+
     def show
       @notification = Ogone::Notification.new(request.query_string)
-      
+
+      @order = Order.find_by_ogone_id(@notification.order_id)
+      if @notification.complete?
+        @order.paid!
+      else
+        @order.failed!
+      end
+    end
+  end
+
+== Example without setting the signatures in the config
+
+If you need to use different signatures each time you can't set them on the
+config. There's a way to set them just when you need them by doing the
+following.
+
+In your view:
+
+  <% payment_service_for @order.ogone_id, OGONE_ACCOUNT,
+      :amount      => @order.price * 100 # needs to be in cents
+      :currency    => 'EUR',
+      :credential2 => current_seller.outbound_signature,
+      :service     => :ogone do |service| %>
+
+    <%  service.redirect :accepturl => checkout_url(@order),
+               :cancelurl => checkout_url(@order),
+               :declineurl => checkout_url(@order),
+               :exceptionurl => checkout_url(@order) %>
+
+    <%= submit_tag "Pay with Ogone!" %>
+  <% end %>
+
+On your controller:
+
+  class CheckoutsController < ApplicationController
+    include ActiveMerchant::Billing::Integrations
+
+    def show
+      @notification = Ogone::Notification.new request.query_string,
+        :signature => current_seller.inbound_signature
+
       @order = Order.find_by_ogone_id(@notification.order_id)
       if @notification.complete?
         @order.paid!

--- a/lib/active_merchant_ogone/helper.rb
+++ b/lib/active_merchant_ogone/helper.rb
@@ -3,7 +3,13 @@ module ActiveMerchant #:nodoc:
     module Integrations #:nodoc:
       module Ogone
         class Helper < ActiveMerchant::Billing::Integrations::Helper
-          
+          attr_reader :outbound_signature
+
+          def initialize(order, account, options = {})
+            super
+            @outbound_signature = options[:credential2]
+          end
+
           # required
           mapping :order,    'orderID'
           mapping :account,  'PSPID'
@@ -25,13 +31,13 @@ module ActiveMerchant #:nodoc:
                              :declineurl   => 'declineurl',
                              :cancelurl    => 'cancelurl',
                              :exceptionurl => 'exceptionurl'
-                             
+
           def customer(mapping = {})
             add_field('ownertelno', mapping[:phone])
             add_field('EMAIL', mapping[:email])
             add_field('CN', "#{mapping[:first_name]} #{mapping[:last_name]}")
           end
-          
+
           def operation operation
             op = case operation
             when :authorization, :auth; 'RES'
@@ -47,13 +53,13 @@ module ActiveMerchant #:nodoc:
             add_field('SHASign', outbound_message_signature)
             super
           end
-          
+
         private
-          
+
           def outbound_message_signature
-            Ogone.outbound_message_signature(@fields)
+            Ogone.outbound_message_signature(@fields, self.outbound_signature)
           end
-          
+
         end
       end
     end

--- a/test/active_merchant_ogone/helper_test.rb
+++ b/test/active_merchant_ogone/helper_test.rb
@@ -20,14 +20,14 @@ class OgoneHelperTest < Test::Unit::TestCase
     assert_field 'CN', 'Jan De Poorter'
     assert_field 'EMAIL', 'ogone@openminds.be'
   end
-  
+
   def test_operation
     @helper.operation :payment
     assert_field 'operation', 'SAL'
-    
+
     @helper.operation :auth
     assert_field 'operation', 'RES'
-    
+
     @helper.operation 'SAL'
     assert_field 'operation', 'SAL'
   end

--- a/test/active_merchant_ogone/helper_test.rb
+++ b/test/active_merchant_ogone/helper_test.rb
@@ -4,7 +4,15 @@ class OgoneHelperTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
 
   def setup
-    @helper = Ogone::Helper.new('order-500','openminds', :amount => 900, :currency => 'EUR')
+    @helper = Ogone::Helper.new 'order-500','openminds', {
+      :amount => 900,
+      :currency => 'EUR',
+      :credential2 => '6df8766fb6d8275e0c0d'
+    }
+  end
+
+  def test_outbound_signature
+    assert_equal '6df8766fb6d8275e0c0d', @helper.outbound_signature 
   end
 
   def test_basic_helper_fields
@@ -56,4 +64,5 @@ class OgoneHelperTest < Test::Unit::TestCase
     @helper.billing_address :street => 'Zilverenberg'
     assert_equal fields, @helper.fields
   end
+
 end

--- a/test/active_merchant_ogone/notification_test.rb
+++ b/test/active_merchant_ogone/notification_test.rb
@@ -4,9 +4,9 @@ class OgoneNotificationTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
 
   Ogone.inbound_signature = '08445a31a78661b5c746feff39a9db6e4e2cc5cf'
-  
+
   SUCCESSFULL_HTTP_RAW_DATA = "orderID=order_342&currency=EUR&amount=50&PM=CreditCard&ACCEPTANCE=test123&STATUS=9&CARDNO=XXXXXXXXXXXX1111&PAYID=2396925&NCERROR=0&BRAND=VISA&IPCTY=BE&CCCTY=US&ECI=7&CVCCheck=NO&AAVCheck=NO&VC=NO&SHASIGN=0B5DB4D379C32331939DA40DCCA16B1556FB6256&IP=82.146.99.233"
-  
+
   FAULTY_HTTP_RAW_DATA = "orderID=order_342&currency=EUR&amount=50&PM=CreditCard&ACCEPTANCE=test123&STATUS=abc&CARDNO=XXXXXXXXXXXX1111&PAYID=2396925&NCERROR=0&BRAND=VISA&IPCTY=BE&CCCTY=US&ECI=7&CVCCheck=NO&AAVCheck=NO&VC=NO&SHASIGN=0B5DB4D379C32331939DA40DCCA16B1556FB6256&IP=82.146.99.233"
 
   def setup
@@ -34,5 +34,5 @@ class OgoneNotificationTest < Test::Unit::TestCase
       Ogone::Notification.new(FAULTY_HTTP_RAW_DATA)
     end
   end
-  
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ $:.unshift(File.dirname(__FILE__) + '/../lib')
 require 'rubygems'
 
 begin
-  gem 'actionpack', '2.3.8'
+  gem 'actionpack', '2.3.11'
 rescue LoadError
   raise StandardError, "The view tests need ActionPack installed as gem to run"
 end
@@ -34,65 +34,65 @@ end
 module ActiveMerchant
   module Assertions
     def assert_field(field, value)
-      clean_backtrace do 
+      clean_backtrace do
         assert_equal value, @helper.fields[field]
       end
     end
-    
-    # Allows the testing of you to check for negative assertions: 
-    # 
+
+    # Allows the testing of you to check for negative assertions:
+    #
     #   # Instead of
     #   assert !something_that_is_false
-    # 
+    #
     #   # Do this
     #   assert_false something_that_should_be_false
-    # 
+    #
     # An optional +msg+ parameter is available to help you debug.
     def assert_false(boolean, message = nil)
       message = build_message message, '<?> is not false or nil.', boolean
-    
+
       clean_backtrace do
         assert_block message do
           not boolean
         end
       end
     end
-    
-    # A handy little assertion to check for a successful response: 
-    # 
+
+    # A handy little assertion to check for a successful response:
+    #
     #   # Instead of
     #   assert_success response
-    # 
+    #
     #   # DRY that up with
     #   assert_success response
-    # 
-    # A message will automatically show the inspection of the response 
+    #
+    # A message will automatically show the inspection of the response
     # object if things go afoul.
     def assert_success(response)
       clean_backtrace do
         assert response.success?, "Response failed: #{response.inspect}"
       end
     end
-    
+
     # The negative of +assert_success+
     def assert_failure(response)
       clean_backtrace do
         assert_false response.success?, "Response expected to fail: #{response.inspect}"
       end
     end
-    
+
     def assert_valid(validateable)
       clean_backtrace do
         assert validateable.valid?, "Expected to be valid"
       end
     end
-    
+
     def assert_not_valid(validateable)
       clean_backtrace do
         assert_false validateable.valid?, "Expected to not be valid"
       end
     end
-    
+
     private
     def clean_backtrace(&block)
       yield
@@ -101,12 +101,12 @@ module ActiveMerchant
       raise Test::Unit::AssertionFailedError, e.message, e.backtrace.reject { |line| File.expand_path(line) =~ /#{path}/ }
     end
   end
-  
+
   module Fixtures
     HOME_DIR = RUBY_PLATFORM =~ /mswin32/ ? ENV['HOMEPATH'] : ENV['HOME'] unless defined?(HOME_DIR)
     LOCAL_CREDENTIALS = File.join(HOME_DIR.to_s, '.active_merchant/fixtures.yml') unless defined?(LOCAL_CREDENTIALS)
     DEFAULT_CREDENTIALS = File.join(File.dirname(__FILE__), 'fixtures.yml') unless defined?(DEFAULT_CREDENTIALS)
-    
+
     private
     def credit_card(number = '4242424242424242', options = {})
       defaults = {
@@ -121,22 +121,22 @@ module ActiveMerchant
 
       Billing::CreditCard.new(defaults)
     end
-    
+
     def check(options = {})
       defaults = {
         :name => 'Jim Smith',
-        :routing_number => '244183602', 
-        :account_number => '15378535', 
-        :account_holder_type => 'personal', 
-        :account_type => 'checking', 
+        :routing_number => '244183602',
+        :account_number => '15378535',
+        :account_holder_type => 'personal',
+        :account_type => 'checking',
         :number => '1'
       }.update(options)
-      
+
       Billing::Check.new(defaults)
     end
-    
+
     def address(options = {})
-      { 
+      {
         :name     => 'Jim Smith',
         :address1 => '1234 My Street',
         :address2 => 'Apt 1',
@@ -149,28 +149,28 @@ module ActiveMerchant
         :fax      => '(555)555-6666'
       }.update(options)
     end
-    
+
     def all_fixtures
       @@fixtures ||= load_fixtures
     end
-    
+
     def fixtures(key)
       data = all_fixtures[key] || raise(StandardError, "No fixture data was found for '#{key}'")
-      
+
       data.dup
     end
-        
+
     def load_fixtures
       file = File.exists?(LOCAL_CREDENTIALS) ? LOCAL_CREDENTIALS : DEFAULT_CREDENTIALS
       yaml_data = YAML.load(File.read(file))
       symbolize_keys(yaml_data)
-    
+
       yaml_data
     end
-    
+
     def symbolize_keys(hash)
       return unless hash.is_a?(Hash)
-      
+
       hash.symbolize_keys!
       hash.each{|k,v| symbolize_keys(v)}
     end


### PR DESCRIPTION
Hi!

With this patch you can support different sellers, each one with its different inbound and outbound signatures. Instead of setting them on the config, you've to set them when you're using them, i.e. in the service helper and when receiving the notification.

Kr,
Fran.
